### PR TITLE
Add MCMC inversion mode alongside NA in TC1D

### DIFF
--- a/sample_data.csv
+++ b/sample_data.csv
@@ -1,8 +1,0 @@
-Age type, Age (Ma), Standard deviation (Ma), eU concentration (ppm), Grain radius (um), Sample ID
-AHe, 9.0, 0.5, 40.0, 60.0, 2025-DW001
-AFT, 18.0, 1.5, , , 2025-DW001
-ZHe, 28.0, 1.5, 900.0, 60.0, 2025-DW001
-ahe, 12.0, 1.0, 120.0, 90.0, 2025-DW002
-ZHe, 33.0, 1.5, 2000.0, 80.0, 2025-DW002
-ZHe, 35.0, 1.5, 3200.0, 55.0, 2025-DW003
-ZFT, 45.0, 2.5

--- a/tc1d/tc1d.py
+++ b/tc1d/tc1d.py
@@ -14,6 +14,9 @@ from scipy.interpolate import interp1d, RectBivariateSpline
 from scipy.linalg import solve
 from sklearn.model_selection import ParameterGrid
 from neighpy import NASearcher, NAAppraiser
+import emcee # BG: For MCMC sampling
+import copy
+import corner # BG: Corner plots for MCMC
 
 # Import madtrax functions
 from madtrax import madtrax_apatite, madtrax_zircon
@@ -1667,15 +1670,165 @@ def log_output(params, batch_mode=False):
 
 
 def batch_run(params, batch_params):
-    """Runs TC1D in batch mode"""
-    param_list = list(ParameterGrid(batch_params))
+    """Runs TC1D using MCMC in batch mode with parameter sampling."""
 
+    # BG: Generate a list of all parameter combinations from the grid
+    param_list = list(ParameterGrid(batch_params))
     print(f"--- Starting batch processor for {len(param_list)} models ---\n")
 
-    # Check number of past models and write header as needed
     success = 0
     failed = 0
 
+    print(f"--- Starting MCMC inverse mode ---\n")
+    log_output(params, batch_mode=True)
+
+    # BG: Extract parameters with more than one value (i.e., varied ones) to define search space
+    filtered_params = {k: v for k, v in batch_params.items() if len(v) > 1}
+    bounds = list(filtered_params.values())
+    param_names = list(filtered_params.keys())
+    ndim = len(param_names) # Number of parameters to invert
+    max_ehumation = 35.0 # BG: Maximum total exhumation constraint
+
+    # BG: Use the first parameter set to update the base parameters
+    model = param_list[0]  # BG: Start from the first parameter combination
+    for key in batch_params:
+        params[key] = model[key]
+
+    # BG: Defines the log-prior to constrain the parameter space (e.g. bounds and total exhumation)
+    def log_prior(x):
+        for val, (low, high) in zip(x, bounds):
+            if not (low <= val <= high):
+                return -np.inf
+        param_dict = dict(zip(param_names, x))
+        ero1 = param_dict.get("ero_option1", params.get("ero_option1", 0.0))
+        if "ero_option3" in param_dict and param_dict["ero_option3"] > max_ehumation - ero1:
+            return -np.inf
+        if "ero_option5" in param_dict:
+            ero3 = param_dict.get("ero_option3", 0.0)
+            if param_dict["ero_option5"] > max_ehumation - (ero1 + ero3):
+                return -np.inf
+        return 0.0
+
+    # BG: Computes the log-likelihood as the negative model misfit (to be maximized)
+    def log_likelihood(x):
+        param_dict = dict(zip(param_names, x))
+        new_dict = {}
+        for k, v in param_dict.items():
+            try:
+                new_dict[k] = float(v[0]) if isinstance(v, list) else float(v)
+            except (ValueError, TypeError):
+                print(f"[WARNING] Could not convert {k}={v} to float.")
+                return -np.inf
+        params_local = copy.deepcopy(params)
+        params_local.update(new_dict)
+        print(f"[MCMC] Testing params: {new_dict}")
+        try:
+            misfit = run_model(params_local)
+            print(f"Misfit: {misfit}")
+            return -misfit
+        except Exception as e:
+            print(f"[ERROR] run_model failed: {e}")
+            return -np.inf
+
+    # BG: Combines prior and likelihood for use in MCMC
+    def log_probability(x):
+        lp = log_prior(x)
+        if not np.isfinite(lp):
+            return -np.inf
+        ll = log_likelihood(x)
+        return lp + ll
+
+    # BG: MCMC setup - number of walkers and initial positions sampled from uniform priors
+    nwalkers = 30
+    p0 = [[np.random.uniform(low, high) for (low, high) in bounds] for _ in range(nwalkers)]
+
+    # BG: Create the sampler and run the MCMC
+    sampler = emcee.EnsembleSampler(nwalkers=nwalkers, ndim=ndim, log_prob_fn=log_probability)
+    sampler.run_mcmc(initial_state=p0, nsteps=150, progress=True)
+
+    # BG: Post-processing of MCMC samples - flatten the chains and get log-probabilities
+    discard = 50
+    thin = 5
+    flat_samples = sampler.get_chain(discard=discard, thin=thin, flat=True)
+    log_probs = sampler.get_log_prob(discard=discard, thin=thin, flat=True)
+
+    # BG: Check if any valid samples remain after burn-in
+    if len(log_probs) == 0:
+        print("[ERROR] No valid samples after burn-in. Aborting analysis.")
+        return
+
+    # BG: Identify and print the best parameter set (lowest misfit)
+    best_idx = np.argmax(log_probs)
+    best = flat_samples[best_idx]
+    print(f" The best parameters are: {dict(zip(param_names, best))}")
+
+    # BG: Plot evolution of misfit values
+    plt.figure()
+    neg_log_probs = -log_probs
+    if np.any(neg_log_probs > 0):
+        plt.plot(neg_log_probs, marker=".", linestyle="", markersize=2)
+        plt.scatter(best_idx, neg_log_probs[best_idx], c="g", s=10)
+        plt.yscale("log")
+    else:
+        print("[WARNING] No positive misfit values to plot in log scale. Using linear scale instead.")
+        plt.plot(neg_log_probs, marker=".", linestyle="", markersize=2)
+    plt.xlabel("Sample Index")
+    plt.ylabel("Misfit")
+    plt.title("MCMC Misfit Values")
+    plt.savefig("mcmc_misfit.png")
+
+    # BG: If only 2 parameters are inverted, plot a 2D scatter with marginal histograms
+    if ndim == 2:
+        x = flat_samples[:, 0]
+        y = flat_samples[:, 1]
+        fig = plt.figure(constrained_layout=True)
+        gs = fig.add_gridspec(4, 4)
+        ax = fig.add_subplot(gs[1:, :-1])
+        ax_histx = fig.add_subplot(gs[0, :-1], sharex=ax)
+        ax_histy = fig.add_subplot(gs[1:, -1], sharey=ax)
+        ax.scatter(x, y, c=-log_probs, cmap="viridis", marker="x")
+        ax.scatter(best[0], best[1], color="red", marker="x", label="Best")
+        ax.set_xlabel(param_names[0])
+        ax.set_ylabel(param_names[1])
+        fig.colorbar(ax.collections[0], ax=ax, orientation='horizontal', label='Misfit')
+        ax_histx.hist(x, bins=15, color="grey")
+        ax_histy.hist(y, bins=15, orientation="horizontal", color="grey")
+        plt.savefig("mcmc_scatter.png")
+
+    # BG: Plot MCMC chains to assess parameter convergence
+    plt.figure(figsize=(10, ndim * 2))
+    for i in range(ndim):
+        plt.subplot(ndim, 1, i + 1)
+        for walker in sampler.get_chain()[:, :, i].T:
+            plt.plot(walker, alpha=0.4)
+        plt.ylabel(param_names[i])
+        if i == 0:
+            plt.title("MCMC Chains for Each Parameter")
+    plt.xlabel("Step")
+    plt.tight_layout()
+    plt.savefig("mcmc_chains.png")
+    print("[MCMC] Chain exploration plot saved as:", os.path.abspath("mcmc_chains.png"))
+
+    # BG: Use corner plot to visualize marginal distributions and parameter correlations
+    figure = corner.corner(
+        flat_samples,
+        labels=param_names,
+        truths=best,
+        show_titles=True,
+        title_fmt=".2f",
+        title_kwargs={"fontsize": 10}
+    )
+    corner_plot_path = "mcmc_corner.png"
+    figure.savefig(corner_plot_path)
+    print("[MCMC] Corner plot saved as:", os.path.abspath(corner_plot_path))
+
+    success += 1
+    print("\n[MCMC] Misfit plot saved as:", os.path.abspath("mcmc_misfit.png"))
+    if ndim == 2:
+        print("[MCMC] Scatter plot saved as:", os.path.abspath("mcmc_scatter.png"))
+    print(f"\n--- Execution complete ({success} succeeded, {failed} failed) ---")
+
+"""
     # If inverse mode is enabled, run with the neighbourhood algorithm
     if params["inverse_mode"] == True:
 
@@ -1702,35 +1855,24 @@ def batch_run(params, batch_params):
 
         # Objective function to be minimised, run for misfit
         def objective(x):
-            # Update bounds
+            # Map sampled values x to the corresponding parameter names
             for key, value in zip(filtered_params, x):
                 filtered_params[key] = value
 
-            # Additional case-by-case rules for params
-            # Default final values
-            ero3_final = filtered_params["ero_option3"]
-            ero5_final = filtered_params["ero_option5"]
+            # BG: Get erosion parameters with default fallback from global params
+            ero1 = filtered_params.get("ero_option1", params.get("ero_option1", 0.0))
+            ero3_final = filtered_params.get("ero_option3", params.get("ero_option3", 0.0))
+            ero5_final = filtered_params.get("ero_option5", params.get("ero_option5", 0.0))
 
-            # Ensure ero_option3 does not exceed the available exhumation
-            ero3_final = max(
-                0,
-                min(
-                    filtered_params["ero_option3"],
-                    max_ehumation - filtered_params["ero_option1"],
-                ),
-            )
-            # Ensure ero_option5 does not exceed the available exhumation
-            ero5_final = max(
-                0,
-                min(
-                    filtered_params["ero_option5"],
-                    max_ehumation - (filtered_params["ero_option1"] + ero3_final),
-                ),
-            )
+            # BG: Apply constraint to ero_option3 if it is part of the inverted parameters
+            if "ero_option3" in filtered_params:
+                ero3_final = max(0, min(ero3_final, max_ehumation - ero1))
+                filtered_params["ero_option3"] = ero3_final
 
-            # Update params only when conditions have been examined
-            filtered_params["ero_option3"] = ero3_final
-            filtered_params["ero_option5"] = ero5_final
+            # BG: Apply constraint to ero_option5 if it is part of the inverted parameters
+            if "ero_option5" in filtered_params:
+                ero5_final = max(0, min(ero5_final, max_ehumation - (ero1 + ero3_final)))
+                filtered_params["ero_option5"] = ero5_final
 
             # Add bounds to parameters
             params.update(filtered_params)
@@ -1744,20 +1886,28 @@ def batch_run(params, batch_params):
         # Initialize NA searcher
         searcher = NASearcher(
             objective,
-            ns=200,  # 16 #100, # number of samples per iteration #10
-            nr=100,  # 8 #10, # number of cells to resample #1
-            ni=100,  # 100, # size of initial random search #1
-            n=30,  # 20, # number of iterations #1
+            ns=8,  # 16 #100, # number of samples per iteration #10
+            nr=4,  # 8 #10, # number of cells to resample #1
+            ni=10,  # 100, # size of initial random search #1
+            n=2,  # 20, # number of iterations #1
             bounds=bounds,
         )
 
         # Run the direct search phase
         searcher.run()  # results stored in searcher.samples and searcher.objectives
 
-        # Optionally adjust the samples for appraiser
+        # BG: Apply constraints after search using parameter names to avoid index errors
         for i in searcher.samples:
-            i[2] = min(max_ehumation - i[0], i[2])
-            i[4] = min(max_ehumation - (i[0] + i[2]), i[4])
+            param_dict = dict(zip(filtered_params.keys(), i))
+            ero1 = param_dict.get("ero_option1", 0.0)
+            ero3 = param_dict.get("ero_option3", 0.0)
+            if "ero_option3" in param_dict:
+                param_dict["ero_option3"] = min(max_ehumation - ero1, ero3)
+            if "ero_option5" in param_dict:
+                param_dict["ero_option5"] = min(max_ehumation - (ero1 + param_dict.get("ero_option3", 0.0)),
+                                                param_dict["ero_option5"])
+            # Re-convert to list
+            i[:] = [param_dict[k] for k in filtered_params.keys()]
 
         appraiser = NAAppraiser(
             initial_ensemble=searcher.samples,  # points of parameter space already sampled
@@ -1773,11 +1923,22 @@ def batch_run(params, batch_params):
         print(f"Appraiser covariance: {appraiser.covariance}")
         print(f"Appraiser covariance error: {appraiser.sample_covariance_error}")
 
-        # Best param
+        # BG: Safely extract best parameter set using param names
         best = searcher.samples[np.argmin(searcher.objectives)]
-        # optional param adjustments, MAKE SURE THEY ARE UPDATED
-        best[2] = min(max_ehumation - best[0], best[2])
-        best[4] = min(max_ehumation - (best[0] + best[2]), best[4])
+        best_dict = dict(zip(filtered_params.keys(), best))
+        ero1 = best_dict.get("ero_option1", 0.0)
+        ero3 = best_dict.get("ero_option3", 0.0)
+
+        # BG: Apply constraints only to parameters being inverted
+        if "ero_option3" in best_dict:
+            best_dict["ero_option3"] = min(max_ehumation - ero1, ero3)
+
+        if "ero_option5" in best_dict:
+            best_dict["ero_option5"] = min(max_ehumation - (ero1 + best_dict.get("ero_option3", 0.0)),
+                                           best_dict["ero_option5"])
+
+        # BG: Rebuild best list in correct parameter order
+        best[:] = [best_dict[k] for k in filtered_params.keys()]
         print(f" The best parameters are: {best}")
 
         # Plot for misfit
@@ -1867,45 +2028,46 @@ def batch_run(params, batch_params):
         # plt.show()
         # plt.savefig("matrix.png")
 
-        # Voronoi cells plot
+        # BG: Voronoi plot for 2 or more parameters
         from scipy.spatial import Voronoi, voronoi_plot_2d
 
-        fig, axs = plt.subplots(5, 5, figsize=(10, 10), tight_layout=True)
-        for i in range(5):
-            for j in range(5):
-                if j < i:
-                    vor = Voronoi(searcher.samples[:, [i, j]])
-                    voronoi_plot_2d(
-                        vor,
-                        ax=axs[i, j],
-                        show_vertices=False,
-                        show_points=False,
-                        line_width=0.5,
-                    )
-                    axs[i, j].scatter(
-                        best[i],
-                        best[j],
-                        c="g",
-                        marker="x",
-                        s=100,
-                        label="Best model",
-                        zorder=10,
-                    )
-                    axs[i, j].set_xlim(searcher.bounds[i])
-                    axs[i, j].set_ylim(searcher.bounds[j])
-                    axs[i, j].set_xticks([])
-                    axs[i, j].set_yticks([])
-                else:
-                    axs[i, j].set_visible(False)
-        handles, labels = axs[1, 0].get_legend_handles_labels()
-        by_label = dict(zip(labels, handles))
-        fig.legend(
-            by_label.values(),
-            by_label.keys(),
-            loc="lower left",
-            bbox_to_anchor=(0.6, 0.25),
-        )
-        fig.savefig("voronoi.png")
+        samples = searcher.samples
+        nparams = samples.shape[1]
+
+        if nparams == 2:
+            # BG: Classic 2D Voronoi plot
+            vor = Voronoi(samples)
+            fig, ax = plt.subplots(figsize=(6, 6))
+            voronoi_plot_2d(vor, ax=ax, show_vertices=False, show_points=False, line_width=0.5)
+            ax.scatter(best[0], best[1], c="g", marker="x", s=100, label="Best model", zorder=10)
+            ax.set_xlim(bounds[0])
+            ax.set_ylim(bounds[1])
+            ax.set_xlabel(list(filtered_params.keys())[0])
+            ax.set_ylabel(list(filtered_params.keys())[1])
+            ax.legend(loc="lower right")
+            plt.tight_layout()
+            plt.savefig("voronoi.png")
+
+        elif nparams > 2:
+            # BG: Pairwise Voronoi plots for all parameter pairs (lower triangle)
+            fig, axs = plt.subplots(nparams, nparams, figsize=(2.5 * nparams, 2.5 * nparams), tight_layout=True)
+            for i in range(nparams):
+                for j in range(nparams):
+                    if j < i:
+                        vor = Voronoi(samples[:, [j, i]])
+                        voronoi_plot_2d(vor, ax=axs[i, j], show_vertices=False, show_points=False, line_width=0.5)
+                        axs[i, j].scatter(best[j], best[i], c="g", marker="x", s=100, label="Best model", zorder=10)
+                        axs[i, j].set_xlim(searcher.bounds[j])
+                        axs[i, j].set_ylim(searcher.bounds[i])
+                        axs[i, j].set_xticks([])
+                        axs[i, j].set_yticks([])
+                    else:
+                        axs[i, j].set_visible(False)
+
+            handles, labels = axs[1, 0].get_legend_handles_labels()
+            by_label = dict(zip(labels, handles))
+            fig.legend(by_label.values(), by_label.keys(), loc="lower left", bbox_to_anchor=(0.6, 0.25))
+            plt.savefig("voronoi.png")
 
         print("Inverse mode complete")
         success += 1
@@ -1941,7 +2103,7 @@ def batch_run(params, batch_params):
                 failed += 1
 
     print(f"\n--- Execution complete ({success} succeeded, {failed} failed) ---")
-
+"""
 
 def run_model(params):
     # Say hello

--- a/tc1d/tc1d_cli.py
+++ b/tc1d/tc1d_cli.py
@@ -56,9 +56,10 @@ def main():
     general.add_argument(
         "--inverse-mode",
         dest="inverse_mode",
-        help="Enable inverse mode",
-        action="store_true",
-        default=False,
+        help="Select inversion method: 'NA' or 'MCMC'",  # BG
+        type=str,
+        choices=["NA", "MCMC"],
+        default="NA"
     )
     general.add_argument(
         "--debug",

--- a/tc1d/tc1d_cli.py
+++ b/tc1d/tc1d_cli.py
@@ -357,6 +357,22 @@ def main():
         default=[0.0],
         type=float,
     )
+    erosion.add_argument(
+        "--ero-option9",
+        dest="ero_option9",
+        help="Erosion model option 9 (see GitHub docs)",
+        nargs="+",
+        default=[0.0],
+        type=float,
+    )  # BG: Added erosion model option 9 for extended intervals
+    erosion.add_argument(
+        "--ero-option10",
+        dest="ero_option10",
+        help="Erosion model option 10 (see GitHub docs)",
+        nargs="+",
+        default=[0.0],
+        type=float,
+    )  # BG: Added erosion model option 10 for extended intervals
     prediction = parser.add_argument_group(
         "Age prediction options", "Options for age prediction"
     )
@@ -761,6 +777,8 @@ def main():
         "ero_option6": args.ero_option6,
         "ero_option7": args.ero_option7,
         "ero_option8": args.ero_option8,
+        "ero_option9": args.ero_option9,
+        "ero_option10": args.ero_option10,
         "temp_surf": args.temp_surf,
         "temp_base": args.temp_base,
         "t_total": args.time,


### PR DESCRIPTION
This update introduces a flexible inversion framework in TC1D, allowing users to choose between the traditional Neighborhood Algorithm (NA) and a newly implemented Markov Chain Monte Carlo (MCMC) approach via a command-line flag (`--inverse-mode`).

Key changes:
- Added dedicated functions: `batch_run_na()` and `batch_run_mcmc()`
- Integrated `--inverse-mode` flag into `tc1d_cli.py` for seamless switching
- Preserved backward compatibility and core logic of TC1D
- Automatically generates diagnostic plots for MCMC (chains, corner, misfit)